### PR TITLE
Init AddressInfo class

### DIFF
--- a/src/AddressInfo.cpp
+++ b/src/AddressInfo.cpp
@@ -1,0 +1,43 @@
+#include "AddressInfo.hpp"
+
+AddressInfo::AddressInfo()
+{
+    struct addrinfo hints = this->_fill_hints();
+
+    // TODO define default port
+    int status = getaddrinfo(NULL, "3490", &hints, &(this->_serv_info));
+
+    this->_check_addr_info_status(status);
+}
+
+AddressInfo::AddressInfo(std::string port)
+{
+    struct addrinfo hints = this->_fill_hints();
+
+    int status = getaddrinfo(NULL, port.c_str(), &hints, &(this->_serv_info));
+
+    this->_check_addr_info_status(status);
+}
+
+AddressInfo::~AddressInfo()
+{
+    freeaddrinfo(this->_serv_info);
+}
+
+struct addrinfo AddressInfo::_fill_hints()
+{
+    struct addrinfo hints;
+
+    memset(&hints, 0, sizeof hints);
+    hints.ai_family = AF_UNSPEC;     // works both for IPv4 and IPv6
+    hints.ai_socktype = SOCK_STREAM; // TCP
+    hints.ai_flags = AI_PASSIVE;     // IP automatically filled
+
+    return hints;
+}
+
+void AddressInfo::_check_addr_info_status(int status)
+{
+    if (status != 0)
+        std::cerr << "getaddrinfo error: " << gai_strerror(status) << std::endl;
+}

--- a/src/AddressInfo.hpp
+++ b/src/AddressInfo.hpp
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <iostream>
+#include <netdb.h>
+#include <string.h>
+#include <sys/socket.h>
+
+class AddressInfo
+{
+private:
+    struct addrinfo *_serv_info;
+
+public:
+    AddressInfo();
+    AddressInfo(std::string port);
+    ~AddressInfo();
+
+private:
+    struct addrinfo _fill_hints();
+    void _check_addr_info_status(int status);
+};


### PR DESCRIPTION
The aim of this PR is introducing the `AddressInfo` class. It will be used to provide a streamlined way of pre-filling an `addrinfo` struct before establishing a connection with a socket.