### PR TITLE
Add unit tests for AddressInfo constructors

### DIFF
--- a/src/AddressInfo.cpp
+++ b/src/AddressInfo.cpp
@@ -24,6 +24,11 @@ AddressInfo::~AddressInfo()
     freeaddrinfo(this->_serv_info);
 }
 
+struct addrinfo *AddressInfo::get_serv_info()
+{
+    return this->_serv_info;
+}
+
 struct addrinfo AddressInfo::_fill_hints()
 {
     struct addrinfo hints;

--- a/src/AddressInfo.hpp
+++ b/src/AddressInfo.hpp
@@ -15,6 +15,8 @@ public:
     AddressInfo(std::string port);
     ~AddressInfo();
 
+    struct addrinfo *get_serv_info();
+
 private:
     struct addrinfo _fill_hints();
     void _check_addr_info_status(int status);

--- a/tests/address_info_class/address_info_class_tests.cpp
+++ b/tests/address_info_class/address_info_class_tests.cpp
@@ -1,0 +1,55 @@
+#include "../utils.hpp"
+
+#include "../../src/AddressInfo.hpp"
+
+#include <iostream>
+#include <netdb.h>
+#include <string.h>
+#include <sys/socket.h>
+
+void address_info_class_tests(bool IS_DEBUG)
+{
+    output_suite_title("ADDRESSINFO CLASS");
+    {
+        std::cout << std::endl
+                  << "Struct should be initialized correctly:" << std::endl;
+        {
+            AddressInfo info;
+
+            //////////////////////////////////////////////
+
+            int status;
+            struct addrinfo hints;
+            struct addrinfo *servinfo;
+
+            memset(&hints, 0, sizeof hints);
+            hints.ai_family = AF_UNSPEC;
+            hints.ai_socktype = SOCK_STREAM;
+            hints.ai_flags = AI_PASSIVE;
+
+            getaddrinfo(NULL, "3490", &hints, &servinfo);
+
+            output_test_assertion("with default constructor", is_strict_equal(*(info.get_serv_info()), *servinfo, IS_DEBUG));
+        }
+        {
+            std::string port = "4200";
+
+            AddressInfo info(port);
+
+            //////////////////////////////////////////////
+
+            int status;
+            struct addrinfo hints;
+            struct addrinfo *servinfo;
+
+            memset(&hints, 0, sizeof hints);
+            hints.ai_family = AF_UNSPEC;
+            hints.ai_socktype = SOCK_STREAM;
+            hints.ai_flags = AI_PASSIVE;
+
+            getaddrinfo(NULL, port.c_str(), &hints, &servinfo);
+
+            output_test_assertion("with parameter constructor (4200)", is_strict_equal(*(info.get_serv_info()), *servinfo, IS_DEBUG));
+        }
+    }
+}

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -1,0 +1,1 @@
+clang++ -Wall -Wextra -Werror *.cpp ../src/*.cpp -o tests && ./tests

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -1,0 +1,13 @@
+#include <iostream>
+
+#include "address_info_class/address_info_class_tests.cpp"
+
+int main(int argc, char *argv[])
+{
+    bool IS_DEBUG = false;
+    if (argc > 1)
+        IS_DEBUG = (static_cast<std::string>(argv[1]) == "debug") ? true : false;
+
+    // AddressInfo class
+    address_info_class_tests(IS_DEBUG);
+}

--- a/tests/utils.hpp
+++ b/tests/utils.hpp
@@ -1,0 +1,88 @@
+#include <iostream>
+#include <netdb.h>
+#include <string.h>
+#include <sys/socket.h>
+
+#define YELLOW "\033[0;33m"
+#define NC "\033[0m"
+
+/**
+ * Outputs the title of a test suite.
+ *
+ * @param title Name of the test suite.
+ */
+void output_suite_title(std::string title)
+{
+    std::cout << std::endl
+              << YELLOW << std::uppercase << title << NC << std::endl;
+}
+
+/**
+ * Outputs the result of a test assertion.
+ *
+ * @param description Description of the test assertion.
+ * @param result Boolean result of a test assertion.
+ */
+void output_test_assertion(std::string description, bool result)
+{
+    bool isErr = result != true;
+    std::cout << "  - " << description << " " << (isErr ? "❌" : "✅") << std::endl;
+    if (isErr)
+        exit(1);
+}
+
+/**
+ * Check if two addrinfo structs are strictly equal.
+ *
+ * @param info1 First addrinfo struct to compare.
+ * @param info2 Second addrinfo struct to compare.
+ * @param IS_DEBUG Boolean indicating if debug output is required.
+ * @return Boolean
+ */
+bool is_strict_equal(const struct addrinfo info1, const struct addrinfo info2, bool IS_DEBUG)
+{
+
+    // addrinfo
+    if (info1.ai_flags != info2.ai_flags)
+    {
+        std::cerr << "ai_flag not equal" << std::endl;
+        return false;
+    }
+    if (info1.ai_family != info2.ai_family)
+    {
+        std::cerr << "ai_family not equal" << std::endl;
+        return false;
+    }
+    if (info1.ai_socktype != info2.ai_socktype)
+    {
+        std::cerr << "ai_socktype not equal" << std::endl;
+        return false;
+    }
+    if (info1.ai_protocol != info2.ai_protocol)
+    {
+        std::cerr << "ai_protocol not equal" << std::endl;
+        return false;
+    }
+    if (info1.ai_addrlen != info2.ai_addrlen)
+    {
+        std::cerr << "ai_addrlen not equal" << std::endl;
+        return false;
+    }
+
+    // TODO check if this is required (not NULL)
+    // if (strcmp(info1.ai_canonname, info2.ai_canonname))
+    //     return false;
+
+    // sockaddr
+    if (info1.ai_addr->sa_family != info2.ai_addr->sa_family)
+    {
+        std::cerr << "ai_addr->sa_family not equal" << std::endl;
+        return false;
+    }
+    if (strcmp(info1.ai_addr->sa_data, info2.ai_addr->sa_data))
+    {
+        std::cerr << "ai_addr->sa_data not equal" << std::endl;
+        return false;
+    }
+    return true;
+}


### PR DESCRIPTION
Add unit tests for AddressInfo constructors. To do so, a new getter exposing AddressInfo had to be added.